### PR TITLE
Fix C++20 build in Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,7 +128,7 @@ jobs:
       fail-fast: false
       matrix:
         disable_aad: ["ON", "OFF"]
-        cxx: ["17"]
+        cxx: ["17", "20"]
     runs-on: windows-2022
     env:
       vsvarsall: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat

--- a/ql/qlrisks.hpp
+++ b/ql/qlrisks.hpp
@@ -478,14 +478,14 @@ namespace boost {
 // MSVC specialisations / fixes
 #ifdef _MSC_VER
 
-#include <random>
-
 // required for random - as it calls ::sqrt on arguments
 using xad::sqrt;
 using xad::pow;
 using xad::exp;
 using xad::log;
 using xad::tan;
+
+#include <random>
 
 namespace std {
 


### PR DESCRIPTION
Together with the latest changes in XAD, only making sure that the XAD math functions used by `<random>` are in global namespace **before** the header is included, fixed the build.

Fixes #18 