### PR TITLE
Template Specialisation Fix (MacOS) Boost 1.87.0

### DIFF
--- a/ql/qlrisks.hpp
+++ b/ql/qlrisks.hpp
@@ -96,7 +96,7 @@ namespace boost {
             };
         }
 
-        // Propagating policies for boost math involving AReal
+        // propagating policies for boost math involving AReal
         namespace policies {
             template <class Policy>
             struct evaluation<xad::AReal<double>, Policy> {

--- a/ql/qlrisks.hpp
+++ b/ql/qlrisks.hpp
@@ -80,22 +80,18 @@ namespace boost {
         // full specialisations for promoting 2 types where one of them is AReal<double>,
         // used by boost math functions a lot
         namespace tools {
-            // partial specialisation
-            template <typename T1, typename T2>
-            struct promote_args_2;
-
             template <>
-            struct promote_args_2<xad::AReal<double>, xad::AReal<double>> {
+            struct promote_args_permissive<xad::AReal<double>, xad::AReal<double>> {
                 typedef xad::AReal<double> type;
             };
 
             template <class T>
-            struct promote_args_2<xad::AReal<double>, T> {
+            struct promote_args_permissive<xad::AReal<double>, T> {
                 typedef xad::AReal<double> type;
             };
 
             template <class T>
-            struct promote_args_2<T, xad::AReal<double>> {
+            struct promote_args_permissive<T, xad::AReal<double>> {
                 typedef xad::AReal<double> type;
             };
         }

--- a/ql/qlrisks.hpp
+++ b/ql/qlrisks.hpp
@@ -80,6 +80,10 @@ namespace boost {
         // full specialisations for promoting 2 types where one of them is AReal<double>,
         // used by boost math functions a lot
         namespace tools {
+            // partial specialisation
+            template <typename T1, typename T2>
+            struct promote_args_2;
+
             template <>
             struct promote_args_2<xad::AReal<double>, xad::AReal<double>> {
                 typedef xad::AReal<double> type;


### PR DESCRIPTION
## Description

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/b938d8d2-3d63-4f2e-9bcd-9ad071e8ddb7" />

MacOS pipelines fail due to specialisation error.

## To Reproduce

Build QuantLib with the Risks-Integration on MacOS with CXX17/20 using the [documented instructions](https://auto-differentiation.github.io/quantlib-risks/cxx/).

## Fix

~We allow a partial template specialisation instead, resulting in a successful build.~
Boost's `promote_args_2` was removed in the latest version, so we use `promote_args_permissive`.
This fix is non-breaking, but with [#155](https://github.com/auto-differentiation/xad/issues/155) open on XAD, the pipelines may still not pass yet.